### PR TITLE
module: adjust module name to be canopennode

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,4 @@
-name: CANopenNode
+name: canopennode
 build:
   cmake-ext: True
   kconfig-ext: True


### PR DESCRIPTION
Adjust the module name to canopennode from CANopenNode. This change
allows relying on the module name to find external Kconfig files in the
Zephyr repository (modules/${MODULE_NAME}/Kconfig).